### PR TITLE
feat: Introducir verificación de estructura de carpetas en los PRs

### DIFF
--- a/.github/workflows/check_folder_structure.yml
+++ b/.github/workflows/check_folder_structure.yml
@@ -1,0 +1,44 @@
+name: Check Folder Structure
+
+on:
+  pull_request:
+    types: opened
+
+jobs:
+  check-folder-structure:
+    runs-on: ubuntu-latest
+    outputs:
+      comment: ${{ steps.check.outputs.comment }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Get changed files
+      id: changed_files
+      uses: tj-actions/changed-files@v37.5.0
+    - name: Check if folder structure is correct
+      id: check
+      run: |
+        PR_USERNAME=$(echo "${{ github.event.pull_request.user.login }}")
+        FILES="${{ steps.changed_files.outputs.all_modified_files }}"
+        IFS=' ' read -r -a FILES_ARR <<< "$FILES"
+        
+        for FILE in "${FILES_ARR[@]}"; do
+          TEST_FOLDER=$(echo ${FILE} | cut -d'/' -f2)
+          if [[ ${FILE} != pruebas/${TEST_FOLDER}/${PR_USERNAME}/* ]]; then
+            echo "Incorrect folder structure in file: ${FILE}. Requesting changes."
+            echo "Asegúrese de que los cambios se realicen en 'pruebas/${TEST_FOLDER}/${PR_USERNAME}/'. :file_folder:" > message.txt
+            echo "::set-output name=comment::$(cat message.txt)"
+            break
+          fi
+        done
+    - name: Comment PR
+      if: steps.check.outputs.comment != ''
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: "${{ steps.check.outputs.comment }}"
+          })


### PR DESCRIPTION
En este Pull Request, introducimos un flujo de trabajo de GitHub Actions que verifica la estructura de las carpetas modificadas en cada PR. La intención es asegurar que cada contribución se haga en una carpeta con el nombre del usuario dentro de la carpeta de prueba correspondiente (por ejemplo, `pruebas/01-reading-list/username`).

Este flujo de trabajo se activa cada vez que se abre un nuevo PR. El flujo de trabajo verifica la estructura de las carpetas en los archivos modificados. Si encuentra algún archivo que no sigue la estructura de carpetas correcta, el flujo de trabajo agrega un comentario al PR indicando el problema y solicitando los cambios necesarios.

El texto del comentario puede ser ajustado, de momento sólo comenta de la siguiente manera:

![image](https://github.com/midudev/pruebas-tecnicas/assets/8385910/56510a27-08c4-4253-a9ae-a4d8e64ca6fb)

