### PR TITLE
feat: renombrar automaticamente el titulo de las "pull request"

### DIFF
--- a/.github/workflows/change_pr_name.yml
+++ b/.github/workflows/change_pr_name.yml
@@ -1,0 +1,31 @@
+name: "Update Title of Pull Request"
+on:
+  pull_request:
+    types:
+      - opened
+    paths:
+      - "pruebas/**"
+
+jobs:
+  update_pr:
+    runs-on: ubuntu-latest
+    steps:
+    - id: files
+      uses: tj-actions/changed-files@v37.5.0
+    - name: Get User Name
+      id: get
+      run: |
+        PR_USERNAME=$(echo "${{ github.event.pull_request.user.login }}")
+        FILES="${{ steps.files.outputs.all }}"
+        TEST_NAME=$(echo ${FILES[0]} | cut -d'-' -f1 | sed "s#pruebas/##")
+
+        echo "::set-output user_name=comment::$PR_USERNAME"
+        echo "::set-output test_name=comment::$TEST_NAME"
+    - uses: tzkhan/pr-update-action@v2
+      env:
+        USER: ${{ steps.get.outputs.user_name }}
+        TEST: ${{ steps.get.outputs.test_name }}
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        title-update-action: "replace"
+        title-template: "Solución a Prueba ${{ env.TEST }} por @${{ env.USER }}"


### PR DESCRIPTION
Este workflow solo puede ser accionado si es una PR nueva y se ha modificado algo en la carpeta `pruebas/`, luego lo que hace es ver que carpeta de pruebas se ha modificado por ejemplo puede ser "01-reading-list" y de aqui es que toma el valor para poder reemplazar en el titulo

Esta PR soluciona el issue #94 sacando de ese issue el template para el titulo del workflow

Titulo entrante: "Mi solucion para el problema numero 1 usando Rust y Yew"
Titulo resultante: "Solución a Prueba 01 por @SergioRibera"